### PR TITLE
feat: cloud-login-first config flow with automatic device onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,14 @@ Before installing this integration, you must install and configure the **Cremali
 1.  Navigate to **Settings** > **Devices & Services**.
 2.  Click **Add Integration**.
 3.  Search for **Cremalink**.
-4.  Follow the configuration flow. [You will need to provide the connection details for the Cremalink Server Add-on.](https://github.com/miditkl/cremalink-ha/discussions/5)
+4.  Sign in with your Cremalink cloud account email and password. The integration
+    automatically discovers your coffee machine(s), detects the correct model, and
+    connects locally (via the add-on) whenever LAN details are available, falling
+    back to the cloud connection otherwise — no device map, DSN, or LAN key to type in.
+5.  Don't have (or don't want to use) a cloud account? Check **Advanced setup** on
+    the first screen to fall back to the previous manual flow: picking a device map
+    and entering the DSN/LAN key/IP (local) or a refresh token (cloud) by hand.
+    [More on the local add-on setup here.](https://github.com/miditkl/cremalink-ha/discussions/5)
 
 ---
 

--- a/custom_components/cremalink_ha/config_flow.py
+++ b/custom_components/cremalink_ha/config_flow.py
@@ -1,14 +1,15 @@
 """Config flow for the Cremalink integration."""
+
+import json
 import logging
 import os
-import json
-import voluptuous as vol
 
+import voluptuous as vol
+from cremalink.devices import get_device_maps, load_device_map
 from homeassistant import config_entries
 from homeassistant.core import HomeAssistant
 
-from cremalink.devices import get_device_maps, load_device_map
-from cremalink import Client
+from cremalink import Client, authenticate_cloud, detect_model_id
 
 from .const import *
 
@@ -47,7 +48,7 @@ def get_map_data(hass: HomeAssistant, map_name: str) -> dict:
         custom_dir = hass.config.path(CUSTOM_MAP_DIR)
         filepath = os.path.join(custom_dir, filename)
         try:
-            with open(filepath, 'r') as f:
+            with open(filepath, "r") as f:
                 return json.load(f)
         except Exception:
             return {}
@@ -67,8 +68,198 @@ class CremalinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     _discovered_devices: list[str] = []
     _selected_map: str | None = None
 
+    # Cloud-assisted onboarding state (spec: Cloud-Assisted Device Onboarding)
+    _cloud_token_file: str | None = None
+    _cloud_devices: list[dict] = []
+    _cloud_selected_device: dict | None = None
+
     async def async_step_user(self, user_input=None):
-        """Handle the initial step (Model Selection)."""
+        """Handle the initial step: cloud login (email/password), replacing the
+        previous device-map-first flow. An "advanced setup" checkbox routes to
+        :meth:`async_step_manual` for users without cloud account access.
+        """
+        errors = {}
+        if user_input is not None:
+            if user_input.get(CONF_MANUAL_SETUP):
+                return await self.async_step_manual()
+
+            email = user_input.get(CONF_EMAIL)
+            password = user_input.get(CONF_PASSWORD)
+            if not email or not password:
+                errors["base"] = "missing_credentials"
+            else:
+
+                def _login_and_discover():
+                    token = authenticate_cloud(email, password)
+                    token_dir = self.hass.config.path(TOKEN_DIR)
+                    os.makedirs(token_dir, exist_ok=True)
+                    temp_file = os.path.join(token_dir, "temp_token.json")
+                    token.save(temp_file)
+                    client = Client(temp_file)
+                    raw_devices = client.get_devices()
+                    coffee_devices = client.list_account_devices()
+                    return temp_file, raw_devices, coffee_devices
+
+                try:
+                    temp_file, raw_devices, coffee_devices = (
+                        await self.hass.async_add_executor_job(_login_and_discover)
+                    )
+                except (
+                    Exception
+                ) as e:
+                    _LOGGER.error("Cloud login failed: %s", e)
+                    errors["base"] = "auth_failed"
+                else:
+                    self._cloud_token_file = temp_file
+                    if not raw_devices:
+                        errors["base"] = "no_devices"
+                    elif not coffee_devices:
+                        errors["base"] = "no_coffee_machine"
+                    else:
+                        self._cloud_devices = coffee_devices
+                        if len(coffee_devices) > 1:
+                            return await self.async_step_device_select()
+                        return await self._async_select_cloud_device(coffee_devices[0])
+
+        return self.async_show_form(
+            step_id="user",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(CONF_EMAIL): str,
+                    vol.Optional(CONF_PASSWORD): str,
+                    vol.Optional(CONF_MANUAL_SETUP, default=False): bool,
+                }
+            ),
+            errors=errors,
+        )
+
+    async def async_step_device_select(self, user_input=None):
+        """Let the user pick which discovered coffee machine to add (>1 found)."""
+        if user_input is not None:
+            dsn = user_input[CONF_DSN]
+            device = next((d for d in self._cloud_devices if d["dsn"] == dsn), None)
+            if device is not None:
+                return await self._async_select_cloud_device(device)
+
+        options = {
+            d["dsn"]: f"{d.get('product_name') or d['dsn']} ({d['dsn']})"
+            for d in self._cloud_devices
+        }
+        return self.async_show_form(
+            step_id="device_select",
+            data_schema=vol.Schema({vol.Required(CONF_DSN): vol.In(options)}),
+        )
+
+    async def _async_select_cloud_device(self, device: dict):
+        """Set the device's unique id, detect its model, and continue the flow."""
+        await self.async_set_unique_id(device["dsn"])
+        self._abort_if_unique_id_configured()
+        self._cloud_selected_device = device
+
+        def _detect():
+            client = Client(self._cloud_token_file)
+            serial = client.get_serial_number(device["dsn"])
+            return detect_model_id(
+                serial,
+                {
+                    "model": device.get("oem_model"),
+                    "product_name": device.get("product_name"),
+                },
+                device.get("oem_model"),
+            )
+
+        model_id = await self.hass.async_add_executor_job(_detect)
+        if model_id is None:
+            return await self.async_step_manual_map()
+        return await self._async_complete_cloud_entry(device, model_id)
+
+    async def async_step_manual_map(self, user_input=None):
+        """Fallback device-map picker when automatic detection is inconclusive.
+
+        Shown only when :func:`detect_model_id` returns ``None`` — the DSN,
+        friendly name, and any LAN details are already known from the cloud
+        discovery step and are not re-requested from the user.
+        """
+        device = self._cloud_selected_device or {}
+        if user_input is not None:
+            return await self._async_complete_cloud_entry(
+                device, user_input[CONF_DEVICE_MAP]
+            )
+
+        maps = await self.hass.async_add_executor_job(get_available_maps, self.hass)
+        return self.async_show_form(
+            step_id="manual_map",
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_DEVICE_MAP): vol.In(maps) if maps else str,
+                }
+            ),
+            description_placeholders={
+                "dsn": device.get("dsn", ""),
+                "device_name": device.get("product_name") or device.get("dsn", ""),
+            },
+        )
+
+    async def _async_complete_cloud_entry(self, device: dict, device_map_id: str):
+        """Fetch LAN details and create the entry as local (if supported and
+        available) or cloud (fallback), per FR-006/FR-007/FR-008.
+        """
+        dsn = device["dsn"]
+        device_name = device.get("product_name") or dsn
+
+        def _fetch_lan():
+            client = Client(self._cloud_token_file)
+            return client.get_lan_config(dsn)
+
+        map_data = await self.hass.async_add_executor_job(
+            get_map_data, self.hass, device_map_id
+        )
+        support = map_data.get("support", {})
+
+        lan = {"lan_enabled": False}
+        if support.get("local"):
+            lan = await self.hass.async_add_executor_job(_fetch_lan)
+
+        if (
+            lan.get("lan_enabled")
+            and lan.get("lan_ip")
+            and lan.get("lanip_key")
+            and support.get("local")
+        ):
+            data = {
+                CONF_CONNECTION_TYPE: CONNECTION_LOCAL,
+                DEVICE_NAME: device_name,
+                CONF_DSN: dsn,
+                CONF_DEVICE_MAP: device_map_id,
+                CONF_ADDON_URL: self._addon_url,
+                CONF_LAN_KEY: lan["lanip_key"],
+                CONF_DEVICE_IP: lan["lan_ip"],
+            }
+            # Local connection doesn't need the cloud refresh token — discard it.
+            if self._cloud_token_file and os.path.exists(self._cloud_token_file):
+                os.remove(self._cloud_token_file)
+        else:
+            token_dir = self.hass.config.path(TOKEN_DIR)
+            final_token_path = os.path.join(token_dir, f"{dsn}.json")
+            if self._cloud_token_file and os.path.exists(self._cloud_token_file):
+                os.rename(self._cloud_token_file, final_token_path)
+            data = {
+                CONF_CONNECTION_TYPE: CONNECTION_CLOUD,
+                DEVICE_NAME: device_name,
+                CONF_DSN: dsn,
+                CONF_DEVICE_MAP: device_map_id,
+                CONF_TOKEN_FILE: final_token_path,
+            }
+
+        return self.async_create_entry(title=device_name, data=data)
+
+    async def async_step_manual(self, user_input=None):
+        """Handle the advanced/manual setup step (device-map picker first).
+
+        This is today's original first step, preserved verbatim for users
+        without cloud account access or who prefer not to use cloud-assisted
+        onboarding (FR-010).
+        """
         errors = {}
         if user_input is not None:
             self._selected_map = user_input[CONF_DEVICE_MAP]
@@ -87,7 +278,7 @@ class CremalinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     menu_options={
                         "local": "Local Network (Add-on) [recommended]",
                         "cloud_auth": "Cloud (Ayla Networks)",
-                    }
+                    },
                 )
             elif local_support:
                 return await self.async_step_local()
@@ -98,11 +289,9 @@ class CremalinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         maps = await self.hass.async_add_executor_job(get_available_maps, self.hass)
         return self.async_show_form(
-            step_id="user",
-            data_schema=vol.Schema({
-                vol.Required(CONF_DEVICE_MAP): vol.In(maps)
-            }),
-            errors=errors
+            step_id="manual",
+            data_schema=vol.Schema({vol.Required(CONF_DEVICE_MAP): vol.In(maps)}),
+            errors=errors,
         )
 
     async def async_step_choose_connection(self, user_input=None):
@@ -130,7 +319,9 @@ class CremalinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
                 def _check():
                     # Check health endpoint of the addon
-                    return requests.get(f"{self._addon_url.rstrip('/')}/health", timeout=5)
+                    return requests.get(
+                        f"{self._addon_url.rstrip('/')}/health", timeout=5
+                    )
 
                 resp = await self.hass.async_add_executor_job(_check)
                 if resp.status_code == 200:
@@ -142,8 +333,10 @@ class CremalinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="local",
-            data_schema=vol.Schema({vol.Required(CONF_ADDON_URL, default=DEFAULT_ADDON_URL): str}),
-            errors=errors
+            data_schema=vol.Schema(
+                {vol.Required(CONF_ADDON_URL, default=DEFAULT_ADDON_URL): str}
+            ),
+            errors=errors,
         )
 
     async def async_step_device(self, user_input=None):
@@ -156,7 +349,7 @@ class CremalinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
         """
         errors = {}
         maps = await self.hass.async_add_executor_job(get_available_maps, self.hass)
-        
+
         if user_input:
             user_input[CONF_ADDON_URL] = self._addon_url
             user_input[CONF_CONNECTION_TYPE] = CONNECTION_LOCAL
@@ -167,7 +360,9 @@ class CremalinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             await self.async_set_unique_id(user_input[CONF_DSN])
             self._abort_if_unique_id_configured()
 
-            return self.async_create_entry(title=f"{user_input[DEVICE_NAME]}", data=user_input)
+            return self.async_create_entry(
+                title=f"{user_input[DEVICE_NAME]}", data=user_input
+            )
 
         schema = {
             vol.Required(DEVICE_NAME): str,
@@ -205,6 +400,7 @@ class CremalinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             temp_file = os.path.join(token_dir, "temp_token.json")
 
             try:
+
                 def _auth_and_fetch():
                     with open(temp_file, "w") as f:
                         json.dump({"refresh_token": refresh_token}, f)
@@ -212,7 +408,9 @@ class CremalinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     client = Client(temp_file)
                     return client.get_devices()
 
-                self._discovered_devices = await self.hass.async_add_executor_job(_auth_and_fetch)
+                self._discovered_devices = await self.hass.async_add_executor_job(
+                    _auth_and_fetch
+                )
                 self._temp_token_file = temp_file
 
                 if not self._discovered_devices:
@@ -229,9 +427,11 @@ class CremalinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
         return self.async_show_form(
             step_id="cloud_auth",
-            data_schema=vol.Schema({
-                vol.Required(CONF_REFRESH_TOKEN): str,
-            }),
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_REFRESH_TOKEN): str,
+                }
+            ),
             errors=errors,
         )
 
@@ -269,7 +469,7 @@ class CremalinkConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                 DEVICE_NAME: dsn,  # Default name, user can change later in HA entity settings
                 CONF_DSN: dsn,
                 CONF_DEVICE_MAP: user_input[CONF_DEVICE_MAP],
-                CONF_TOKEN_FILE: final_token_path
+                CONF_TOKEN_FILE: final_token_path,
             }
 
             return self.async_create_entry(title=dsn, data=data)

--- a/custom_components/cremalink_ha/const.py
+++ b/custom_components/cremalink_ha/const.py
@@ -13,6 +13,13 @@ CONF_CONNECTION_TYPE = "connection_type"
 CONF_REFRESH_TOKEN = "refresh_token"
 CONF_TOKEN_FILE = "token_file"
 
+# Cloud-assisted onboarding (cloud login replaces manual device-map/DSN entry)
+CONF_EMAIL = "email"
+CONF_PASSWORD = "password"
+CONF_REGION = "region"
+CONF_MANUAL_SETUP = "manual_setup"
+DEFAULT_REGION = "EU"  # only region with valid app credentials for v1 — see research.md #1
+
 CONNECTION_LOCAL = "local"
 CONNECTION_CLOUD = "cloud"
 

--- a/custom_components/cremalink_ha/diagnostics.py
+++ b/custom_components/cremalink_ha/diagnostics.py
@@ -1,0 +1,36 @@
+"""Diagnostics support for Cremalink.
+
+Redacts the sensitive fields introduced by cloud-assisted onboarding
+(spec FR-013): cloud account email/password, access/refresh tokens, and
+the LAN key. Modeled directly on ``delonghi_coffee``'s ``diagnostics.py``.
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.diagnostics import async_redact_data
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+
+from .const import DOMAIN
+
+REDACT_KEYS: set[str] = {
+    "email",
+    "password",
+    "access_token",
+    "refresh_token",
+    "lan_key",
+    "device_ip",
+}
+
+
+async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigEntry) -> dict[str, Any]:
+    """Return diagnostics for a config entry, with sensitive fields redacted."""
+    data = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
+    coordinator = data.get("coordinator")
+
+    return {
+        "entry_data": async_redact_data(dict(entry.data), REDACT_KEYS),
+        "entry_options": async_redact_data(dict(entry.options), REDACT_KEYS),
+        "coordinator_data": async_redact_data(getattr(coordinator, "data", None) or {}, REDACT_KEYS),
+    }

--- a/custom_components/cremalink_ha/manifest.json
+++ b/custom_components/cremalink_ha/manifest.json
@@ -11,6 +11,6 @@
     "cremalink==0.1.0b26"
   ],
   "issue_tracker": "https://github.com/miditkl/cremalink-ha/issues",
-  "version": "v0.1.0b26",
+  "version": "v0.2.0b1",
   "quality_scale": "bronze"
 }

--- a/custom_components/cremalink_ha/strings.json
+++ b/custom_components/cremalink_ha/strings.json
@@ -2,6 +2,29 @@
   "config": {
     "step": {
       "user": {
+        "title": "Sign in to your Cremalink cloud account",
+        "description": "Enter your cloud account email and password to automatically discover and set up your coffee machine. Check \"Advanced setup\" to configure a device manually instead.",
+        "data": {
+          "email": "Email",
+          "password": "Password",
+          "manual_setup": "Advanced setup (configure manually instead)"
+        }
+      },
+      "device_select": {
+        "title": "Select Device",
+        "description": "Your cloud account has more than one coffee machine. Choose which one to add.",
+        "data": {
+          "dsn": "Device"
+        }
+      },
+      "manual_map": {
+        "title": "Select Device Model",
+        "description": "We could not automatically identify the model for {device_name} ({dsn}). Please select it manually.",
+        "data": {
+          "device_map": "Device Model"
+        }
+      },
+      "manual": {
         "title": "Select Connection Method",
         "description": "Choose how you want to connect to your Cremalink device.",
         "menu_options": {
@@ -45,8 +68,10 @@
     },
     "error": {
       "cannot_connect": "Could not connect to server. Is the URL correct and the server running?",
-      "auth_failed": "Authentication failed. Please check your refresh token.",
+      "auth_failed": "Authentication failed. Please check your credentials.",
+      "missing_credentials": "Please enter both email and password, or check Advanced setup.",
       "no_devices": "No devices found on this account.",
+      "no_coffee_machine": "This account has devices, but none of them are recognized as a coffee machine.",
       "unknown": "Unknown error occurred"
     },
     "abort": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,15 @@
 [project]
 name = "cremalink-ha"
-version = "v0.1.0b26"
+version = "v0.2.0b1"
 description = "Cremalink for Home-Assistant Add-on & Integration"
 requires-python = ">=3.13.2"
 dependencies = [
     "homeassistant>=2026.2.3",
     "cremalink==0.1.0b26"
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
+[tool.coverage.run]
+source = ["custom_components/cremalink_ha"]

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,0 +1,5 @@
+pytest>=9.0.3
+pytest-cov>=7.1.0
+requests>=2.33.1
+voluptuous>=0.16.0
+cryptography>=48.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,88 @@
+"""Shared fixtures for Cremalink tests.
+
+Mock homeassistant at module level so imports work during collection.
+Ported from delonghi-ha/tests/conftest.py's approach: stub HA modules with
+MagicMock, then replace the specific bases config_flow.py/diagnostics.py
+actually subclass or call with real, minimal stand-ins.
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+_HA_MODULES = [
+    "homeassistant",
+    "homeassistant.core",
+    "homeassistant.config_entries",
+    "homeassistant.const",
+    "homeassistant.exceptions",
+    "homeassistant.helpers",
+    "homeassistant.helpers.update_coordinator",
+    "homeassistant.data_entry_flow",
+    "homeassistant.components",
+    "homeassistant.components.diagnostics",
+]
+
+
+def _real_redact(data, keys_to_redact):
+    """Stand-in for HA's async_redact_data — redacts top-level keys."""
+    if not isinstance(data, dict):
+        return data
+    return {k: ("**REDACTED**" if k in keys_to_redact else v) for k, v in data.items()}
+
+
+for mod_name in _HA_MODULES:
+    if mod_name not in sys.modules:
+        sys.modules[mod_name] = MagicMock()
+
+sys.modules["homeassistant.components.diagnostics"].async_redact_data = _real_redact
+
+
+# Real ConfigFlow stub so config_flow.py's `class Foo(ConfigFlow, domain=...)`
+# subclasses a real class instead of silently producing a MagicMock.
+class _ConfigFlowBase:
+    """Stand-in for HA's config_entries.ConfigFlow base."""
+
+    def __init_subclass__(cls, **_kwargs) -> None:  # accept domain= kwarg
+        super().__init_subclass__()
+
+    async def async_set_unique_id(self, unique_id: str) -> None:
+        self.unique_id = unique_id
+
+    def _abort_if_unique_id_configured(self) -> None:
+        return None
+
+    def async_create_entry(self, *, title: str, data: dict) -> dict:
+        return {"type": "create_entry", "title": title, "data": data}
+
+    def async_show_form(self, *, step_id: str, data_schema=None, errors=None, description_placeholders=None) -> dict:
+        return {
+            "type": "form",
+            "step_id": step_id,
+            "data_schema": data_schema,
+            "errors": errors or {},
+            "description_placeholders": description_placeholders,
+        }
+
+    def async_show_menu(self, *, step_id: str, menu_options=None) -> dict:
+        return {"type": "menu", "step_id": step_id, "menu_options": menu_options}
+
+    def async_abort(self, *, reason: str) -> dict:
+        return {"type": "abort", "reason": reason}
+
+
+_ce_mod = sys.modules["homeassistant.config_entries"]
+_ce_mod.ConfigFlow = _ConfigFlowBase
+
+_ha_mod = sys.modules["homeassistant"]
+_ha_mod.config_entries = _ce_mod
+_ha_mod.const = sys.modules["homeassistant.const"]
+_ha_mod.core = sys.modules["homeassistant.core"]
+_ha_mod.exceptions = sys.modules["homeassistant.exceptions"]
+_ha_mod.helpers = sys.modules["homeassistant.helpers"]
+_ha_mod.components = sys.modules["homeassistant.components"]
+
+_exc_mod = sys.modules["homeassistant.exceptions"]
+_exc_mod.ConfigEntryNotReady = type("ConfigEntryNotReady", (Exception,), {})
+_exc_mod.HomeAssistantError = type("HomeAssistantError", (Exception,), {})
+
+sys.modules["homeassistant.const"].Platform = MagicMock()

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,199 @@
+"""Tests for the cloud-assisted onboarding config flow (config_flow.py).
+
+Covers spec US1 (cloud login replaces manual device-map/DSN entry), US2
+(automatic model detection + manual fallback), US3 (automatic LAN
+discovery -> local connection), and US4 (graceful cloud-only fallback).
+"""
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+from custom_components.cremalink_ha import config_flow as cf_mod
+from custom_components.cremalink_ha.config_flow import CremalinkConfigFlow
+from custom_components.cremalink_ha.const import (
+    CONF_CONNECTION_TYPE,
+    CONF_DEVICE_MAP,
+    CONF_DSN,
+    CONNECTION_CLOUD,
+    CONNECTION_LOCAL,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _make_hass(tmp_path):
+    hass = MagicMock()
+
+    async def _executor(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    hass.async_add_executor_job = _executor
+    hass.config.path = lambda *parts: str(tmp_path.joinpath(*parts))
+    return hass
+
+
+def _make_flow(hass) -> CremalinkConfigFlow:
+    flow = CremalinkConfigFlow()
+    flow.hass = hass
+    flow.context = {}
+    return flow
+
+
+class _FakeToken:
+    def save(self, path):
+        with open(path, "w") as f:
+            f.write("{}")
+        return path
+
+
+class _FakeClient:
+    """Configurable fake cremalink.Client, controlled via class attrs."""
+
+    raw_devices: list = []
+    coffee_devices: list = []
+    serial = None
+    lan_config = {"lan_enabled": False, "lanip_key": None, "lan_ip": None, "status": None}
+
+    def __init__(self, token_path):
+        self.token_path = token_path
+
+    def get_devices(self):
+        return _FakeClient.raw_devices
+
+    def list_account_devices(self):
+        return _FakeClient.coffee_devices
+
+    def get_serial_number(self, dsn):
+        return _FakeClient.serial
+
+    def get_lan_config(self, dsn):
+        return _FakeClient.lan_config
+
+
+@pytest.fixture(autouse=True)
+def _patch_cloud(monkeypatch):
+    monkeypatch.setattr(cf_mod, "authenticate_cloud", lambda email, password: _FakeToken())
+    monkeypatch.setattr(cf_mod, "Client", _FakeClient)
+    monkeypatch.setattr(cf_mod, "get_available_maps", lambda hass: ["ECAM452", "ECAM612"])
+    monkeypatch.setattr(cf_mod, "get_map_data", lambda hass, name: {"support": {"local": True, "cloud": True}})
+    _FakeClient.raw_devices = []
+    _FakeClient.coffee_devices = []
+    _FakeClient.serial = None
+    _FakeClient.lan_config = {"lan_enabled": False, "lanip_key": None, "lan_ip": None, "status": None}
+    yield
+
+
+class TestCloudLoginStep:
+    def test_single_coffee_device_creates_entry_without_prompt(self, tmp_path, monkeypatch):
+        _FakeClient.raw_devices = ["DSN1"]
+        _FakeClient.coffee_devices = [
+            {"dsn": "DSN1", "product_name": "PrimaDonna", "oem_model": "DL-pd-soul", "lan_enabled": False}
+        ]
+        monkeypatch.setattr(cf_mod, "detect_model_id", lambda *a, **k: "ECAM452")
+
+        flow = _make_flow(_make_hass(tmp_path))
+        result = _run(flow.async_step_user({"email": "a@b.com", "password": "pw", "manual_setup": False}))
+
+        assert result["type"] == "create_entry"
+        assert result["data"][CONF_DSN] == "DSN1"
+        assert result["data"][CONF_DEVICE_MAP] == "ECAM452"
+
+    def test_multi_device_account_shows_device_select(self, tmp_path):
+        _FakeClient.raw_devices = ["DSN1", "DSN2"]
+        _FakeClient.coffee_devices = [
+            {"dsn": "DSN1", "product_name": "PrimaDonna", "oem_model": "DL-pd-soul"},
+            {"dsn": "DSN2", "product_name": "Dinamica", "oem_model": "DL-dinamica-plus"},
+        ]
+
+        flow = _make_flow(_make_hass(tmp_path))
+        result = _run(flow.async_step_user({"email": "a@b.com", "password": "pw", "manual_setup": False}))
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "device_select"
+
+    def test_invalid_credentials_show_auth_failed(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(cf_mod, "authenticate_cloud", lambda email, password: (_ for _ in ()).throw(ValueError("bad creds")))
+
+        flow = _make_flow(_make_hass(tmp_path))
+        result = _run(flow.async_step_user({"email": "a@b.com", "password": "wrong", "manual_setup": False}))
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "user"
+        assert result["errors"]["base"] == "auth_failed"
+
+    def test_zero_coffee_devices_shows_no_coffee_machine_error(self, tmp_path):
+        _FakeClient.raw_devices = ["DSN1"]
+        _FakeClient.coffee_devices = []
+
+        flow = _make_flow(_make_hass(tmp_path))
+        result = _run(flow.async_step_user({"email": "a@b.com", "password": "pw", "manual_setup": False}))
+
+        assert result["errors"]["base"] == "no_coffee_machine"
+
+    def test_zero_devices_shows_no_devices_error(self, tmp_path):
+        _FakeClient.raw_devices = []
+        _FakeClient.coffee_devices = []
+
+        flow = _make_flow(_make_hass(tmp_path))
+        result = _run(flow.async_step_user({"email": "a@b.com", "password": "pw", "manual_setup": False}))
+
+        assert result["errors"]["base"] == "no_devices"
+
+    def test_advanced_setup_checkbox_routes_to_manual_step_unchanged(self, tmp_path):
+        flow = _make_flow(_make_hass(tmp_path))
+        result = _run(flow.async_step_user({"email": "", "password": "", "manual_setup": True}))
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "manual"
+
+
+class TestModelDetectionFallback:
+    def test_unresolved_model_routes_to_manual_map_prefilled(self, tmp_path, monkeypatch):
+        _FakeClient.raw_devices = ["DSN1"]
+        _FakeClient.coffee_devices = [{"dsn": "DSN1", "product_name": "Mystery Machine", "oem_model": "DL-unknown"}]
+        monkeypatch.setattr(cf_mod, "detect_model_id", lambda *a, **k: None)
+
+        flow = _make_flow(_make_hass(tmp_path))
+        result = _run(flow.async_step_user({"email": "a@b.com", "password": "pw", "manual_setup": False}))
+
+        assert result["type"] == "form"
+        assert result["step_id"] == "manual_map"
+        assert result["description_placeholders"]["dsn"] == "DSN1"
+        assert result["description_placeholders"]["device_name"] == "Mystery Machine"
+
+        result2 = _run(flow.async_step_manual_map({CONF_DEVICE_MAP: "ECAM612"}))
+        assert result2["type"] == "create_entry"
+        assert result2["data"][CONF_DEVICE_MAP] == "ECAM612"
+
+
+class TestLocalConnectionCompletion:
+    def test_lan_enabled_and_local_supported_creates_local_entry(self, tmp_path, monkeypatch):
+        _FakeClient.raw_devices = ["DSN1"]
+        _FakeClient.coffee_devices = [{"dsn": "DSN1", "product_name": "PrimaDonna", "oem_model": "DL-pd-soul"}]
+        _FakeClient.lan_config = {"lan_enabled": True, "lanip_key": "KEY123", "lan_ip": "192.168.1.5", "status": "Online"}
+        monkeypatch.setattr(cf_mod, "detect_model_id", lambda *a, **k: "ECAM452")
+
+        flow = _make_flow(_make_hass(tmp_path))
+        result = _run(flow.async_step_user({"email": "a@b.com", "password": "pw", "manual_setup": False}))
+
+        assert result["type"] == "create_entry"
+        assert result["data"][CONF_CONNECTION_TYPE] == CONNECTION_LOCAL
+        assert result["data"]["lan_key"] == "KEY123"
+        assert result["data"]["device_ip"] == "192.168.1.5"
+
+
+class TestCloudFallbackCompletion:
+    def test_lan_disabled_completes_as_cloud_automatically(self, tmp_path, monkeypatch):
+        _FakeClient.raw_devices = ["DSN1"]
+        _FakeClient.coffee_devices = [{"dsn": "DSN1", "product_name": "PrimaDonna", "oem_model": "DL-pd-soul"}]
+        _FakeClient.lan_config = {"lan_enabled": False, "lanip_key": None, "lan_ip": None, "status": None}
+        monkeypatch.setattr(cf_mod, "detect_model_id", lambda *a, **k: "ECAM452")
+
+        flow = _make_flow(_make_hass(tmp_path))
+        result = _run(flow.async_step_user({"email": "a@b.com", "password": "pw", "manual_setup": False}))
+
+        assert result["type"] == "create_entry"
+        assert result["data"][CONF_CONNECTION_TYPE] == CONNECTION_CLOUD
+        assert "token_file" in result["data"]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,42 @@
+"""Tests for diagnostics.py redaction of cloud-assisted onboarding secrets."""
+import asyncio
+from unittest.mock import MagicMock
+
+from custom_components.cremalink_ha.const import DOMAIN
+from custom_components.cremalink_ha.diagnostics import (
+    REDACT_KEYS,
+    async_get_config_entry_diagnostics,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_diagnostics_redacts_sensitive_fields():
+    entry = MagicMock()
+    entry.data = {
+        "email": "user@example.com",
+        "password": "hunter2",
+        "access_token": "at-secret",
+        "refresh_token": "rt-secret",
+        "lan_key": "lan-secret",
+        "device_ip": "192.168.1.5",
+        "dsn": "DSN1",
+        "device_map": "ECAM452",
+    }
+    entry.options = {}
+    entry.entry_id = "entry1"
+
+    hass = MagicMock()
+    coordinator = MagicMock()
+    coordinator.data = {"status": "ok"}
+    hass.data = {DOMAIN: {"entry1": {"coordinator": coordinator}}}
+
+    result = _run(async_get_config_entry_diagnostics(hass, entry))
+
+    redacted = result["entry_data"]
+    for key in REDACT_KEYS:
+        assert redacted[key] == "**REDACTED**"
+    assert redacted["dsn"] == "DSN1"
+    assert redacted["device_map"] == "ECAM452"


### PR DESCRIPTION
- New async_step_user: cloud email/password login (region fixed to EU), discovers coffee machines via cremalink.Client.list_account_devices()
- async_step_device_select for accounts with more than one coffee machine
- Automatic model detection via cremalink.detect_model_id(), falling back to a pre-filled manual device-map picker (async_step_manual_map) when inconclusive
- Automatic LAN config discovery -> local connection when supported, else cloud connection fallback
- Previous device-map-first flow preserved as async_step_manual, reachable via an "Advanced setup" checkbox on the login screen
- New diagnostics.py redacting email/password/tokens/LAN key
- New tests/ (conftest.py HA-module stubs, test_config_flow.py, test_diagnostics.py) and requirements_test.txt
- Bump version to v0.2.0b1
- README: document the new cloud-assisted onboarding flow

Part of specs/001-cloud-assisted-onboarding.